### PR TITLE
fix: Remove self on heartbeat

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Incident {
 
 impl Uptime {
     /// Ping the Uptime API to make sure that the service is up: https://betterstack.com/docs/uptime/cron-and-heartbeat-monitor/
-    pub async fn heartbeat(&self, identifier: String) -> Result<()> {
+    pub async fn heartbeat(identifier: String) -> Result<()> {
         let url = format!("{API_URL}/v1/heartbeat/{identifier}");
         match reqwest::get(url).await?.error_for_status() {
             Ok(_) => Ok(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Incident {
 
 impl Uptime {
     /// Ping the Uptime API to make sure that the service is up: https://betterstack.com/docs/uptime/cron-and-heartbeat-monitor/
-    pub async fn heartbeat(identifier: String) -> Result<()> {
+    pub async fn heartbeat(identifier: &str) -> Result<()> {
         let url = format!("{API_URL}/v1/heartbeat/{identifier}");
         match reqwest::get(url).await?.error_for_status() {
             Ok(_) => Ok(()),


### PR DESCRIPTION
The token isn't used in heartbeat, most usage is a heartbeat alone. While i don't think it is too useful to have a token in the struct at all i think let's remove self from heartbeat at least